### PR TITLE
Handle number matching and highlighting

### DIFF
--- a/src/components/BingoCard.tsx
+++ b/src/components/BingoCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 
 interface BingoCell {
@@ -79,6 +79,21 @@ export const BingoCard = ({ playerId, onCellMark, calledNumbers, className }: Bi
 
     onCellMark?.(row, col);
   };
+
+  // Update cell "called" status whenever calledNumbers prop changes
+  useEffect(() => {
+    setCard(prev =>
+      prev.map(column =>
+        column.map(cell => {
+          // If the cell has a number and it exists in the called numbers list, mark it as called
+          if (cell.number && calledNumbers.includes(cell.number) && !cell.called) {
+            return { ...cell, called: true };
+          }
+          return cell;
+        })
+      )
+    );
+  }, [calledNumbers]);
 
   return (
     <div className={cn("bg-card border border-border rounded-xl p-4 shadow-lg", className)}>


### PR DESCRIPTION
Automatically mark bingo card cells as 'called' when their number is announced to enable player interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ba57eba-f326-451e-b912-daddd670a7c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ba57eba-f326-451e-b912-daddd670a7c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>